### PR TITLE
Identified memory bug in ColorChangingTimerButton

### DIFF
--- a/covmatic_lws/gui/buttons.py
+++ b/covmatic_lws/gui/buttons.py
@@ -1,13 +1,10 @@
 import tkinter as tk
 import tkinter.messagebox
 import subprocess
-import threading
 from typing import Tuple, List
 from . import _kill_app
 from .utils import setIntervalForTimerButton
 from ..ssh import try_ssh
-import psutil
-import os
 
 _palette = {
     "off": {
@@ -125,19 +122,10 @@ class ColorChangingTimerButton(ColorChangingButton):
 
     @setIntervalForTimerButton
     def _loop(self):
-        print("updating trhread...")
-        PROCESS = psutil.Process(os.getpid())
-
-        def get_mem_usage():
-            return PROCESS.memory_info().rss // 1024
-        print("Memory: {}".format(get_mem_usage()))
-        print("thread: {}".format(threading.active_count()))
         self.update()
     
     def update_thread(self):
-        print("update_thread")
         func = self._loop()      # call func.set() to stop looping
-        print("Exit from update_thread")
     
     def destroy(self):
         if self._thread is not None:

--- a/covmatic_lws/gui/buttons.py
+++ b/covmatic_lws/gui/buttons.py
@@ -4,8 +4,10 @@ import subprocess
 import threading
 from typing import Tuple, List
 from . import _kill_app
+from .utils import setIntervalForTimerButton
 from ..ssh import try_ssh
-
+import psutil
+import os
 
 _palette = {
     "off": {
@@ -120,14 +122,22 @@ class ColorChangingTimerButton(ColorChangingButton):
         self._interval = interval
         self._thread = None
         self.update_thread()
-    
-    def _update_thread(self):
+
+    @setIntervalForTimerButton
+    def _loop(self):
+        print("updating trhread...")
+        PROCESS = psutil.Process(os.getpid())
+
+        def get_mem_usage():
+            return PROCESS.memory_info().rss // 1024
+        print("Memory: {}".format(get_mem_usage()))
+        print("thread: {}".format(threading.active_count()))
         self.update()
-        self.update_thread()
     
     def update_thread(self):
-        self._thread = threading.Timer(self._interval, self._update_thread)
-        self._thread.start()
+        print("update_thread")
+        func = self._loop()      # call func.set() to stop looping
+        print("Exit from update_thread")
     
     def destroy(self):
         if self._thread is not None:

--- a/covmatic_lws/gui/utils.py
+++ b/covmatic_lws/gui/utils.py
@@ -1,3 +1,4 @@
+import threading
 import tkinter as tk
 import tkinter.messagebox
 from functools import wraps
@@ -12,6 +13,30 @@ def warningbox(foo):
             tk.messagebox.showwarning(type(e).__name__, str(e))
     return foo_
 
+
+def setIntervalForTimerButton(function):
+    '''
+    This decorator starts a thread with the decorated function as loop;
+    The first argument of the function must contain the _interval property.
+    Args:
+        function: the decorated function
+
+    Returns:
+
+    '''
+    def wrapper(*args, **kwargs):
+        stopped = threading.Event()
+        interval = args[0]._interval
+
+        def _loop(): # executed in another thread
+            while not stopped.wait(interval): # until stopped
+                function(*args, **kwargs)
+
+        t = threading.Thread(target=_loop)
+        t.daemon = True # stop if the program exits
+        t.start()
+        return stopped
+    return wrapper
 
 # Copyright (c) 2020 Covmatic.
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
- What happens:
It has been seen that the covmatic_lws.gui module fills the available memory (e.g. 2GB) and than throws the error "cannot start a new thread" trying to press every button.

- Steps to reproduce
keep the LWS open for some hours. The memory keep growing in a linear manner at a rate of 0.1MB/s

In this PR a decorator is added that wraps the function inside a while loop; 
I think the problem is that for some reason the old threads are not garbage-collected, since they're all inside a nested call loop maybe.
Creating this PR just to keep trace of the problem